### PR TITLE
Add mixed hypergraphs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,4 @@ docs/_build/
 # Test artifacts
 test_directed_read_and_write.txt
 test_undirected_read_and_write.txt
+test_mixed_read_and_write.txt

--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,7 @@ coverage.xml
 docs/_build/
 
 /main.py
+
+# Test artifacts
+test_directed_read_and_write.txt
+test_undirected_read_and_write.txt

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 halp: Hypergraph Algorithms Package<br>
 ==========
 
-_halp_ is a Python software package that provides both a directed and an undirected hypergraph implementation, as well as several important and canonical algorithms that operate on these hypergraphs.
+_halp_ is a Python software package that provides directed, undirected, and mixed hypergraph implementations, as well as several important and canonical algorithms that operate on these hypergraphs.
 
 See [http://murali-group.github.io/halp/](http://murali-group.github.io/halp/) for documentation, code examples, and more information.
 

--- a/halp/algorithms/directed_random_walk.py
+++ b/halp/algorithms/directed_random_walk.py
@@ -30,13 +30,13 @@ def stationary_distribution(H, pi=None, P=None):
             it will be created.
     :returns: list -- list of the stationary probabilities for all nodes
             in the hypergraph.
-    :raises: TypeError -- Algorithm only applicable to undirected hypergraphs
+    :raises: TypeError -- Algorithm only applicable to directed hypergraphs
     :raises: AssertionError -- Each node must have at least 1 outgoing
              hyperedge (even if it's only a self-loop).
 
     """
     if not isinstance(H, DirectedHypergraph):
-        raise TypeError("Algorithm only applicable to undirected hypergraphs")
+        raise TypeError("Algorithm only applicable to directed hypergraphs")
 
     for node in H.node_iterator():
         if len(H.get_forward_star(node)) == 0:

--- a/halp/directed_hypergraph.py
+++ b/halp/directed_hypergraph.py
@@ -349,7 +349,7 @@ class DirectedHypergraph(object):
             self.remove_node(node)
 
     def trim_node(self, node):
-        """Removes a node from the hypergraph. Modifies hypredges with the 
+        """Removes a node from the hypergraph. Modifies hyperedges with the 
         trimmed node in their head or tail so that they no longer include 
         the trimmed node. If a hyperedge has solely the trimmed node in its
         head or tail, that hyperedge is removed.

--- a/halp/directed_hypergraph.py
+++ b/halp/directed_hypergraph.py
@@ -366,10 +366,6 @@ class DirectedHypergraph(object):
             >>> H.trim_node('A')
         """
     
-        fs = self.get_forward_star(node)
-        bs = self.get_backward_star(node)
-        remove_set = set()
-    
         def get_attrs(H, hyperedge):
             #copies the attribute dictionary of a hyperedge except for the head and tail
             new_attrs = {}
@@ -379,6 +375,10 @@ class DirectedHypergraph(object):
                 if key not in {'head', 'tail'}:
                     new_attrs[key] = old_attrs[key]
             return new_attrs
+        
+        remove_set = set()
+        fs = self.get_forward_star(node)
+        bs = self.get_backward_star(node)
     
         for hedge in fs:
             tail = set(self.get_hyperedge_tail(hedge))

--- a/halp/directed_hypergraph.py
+++ b/halp/directed_hypergraph.py
@@ -1249,7 +1249,7 @@ class DirectedHypergraph(object):
                     raise ValueError(
                         'Consistency Check 1.7 Failed: hyperedge ' +
                         'id ' + hyperedge_id + ' is not in the ' +
-                        'backward star of head node ' + tail_node)
+                        'backward star of head node ' + head_node)
 
     def _check_node_attributes_consistency(self):
         """Consistency Check 2: consider all nodes listed in

--- a/halp/mixed_hypergraph.py
+++ b/halp/mixed_hypergraph.py
@@ -387,7 +387,7 @@ class MixedHypergraph(object):
 
     # WIP convert
     def trim_node(self, node):
-        """Removes a node from the hypergraph. Modifies hypredges with the 
+        """Removes a node from the hypergraph. Modifies hyperedges with the 
         trimmed node in their head or tail so that they no longer include 
         the trimmed node. If a hyperedge has solely the trimmed node in its
         head or tail, that hyperedge is removed.

--- a/halp/mixed_hypergraph.py
+++ b/halp/mixed_hypergraph.py
@@ -1141,13 +1141,13 @@ class MixedHypergraph(object):
         return self._star[node].copy()
 
     def get_successors(self, tail):
-        """Given a tail set of nodes, get a list of edges of which the node
-        set is the tail of each edge.
+        """Given a tail set of nodes, get a list of directed hyperedges of
+        which the node set is the tail of each edge.
 
         :param tail: set of nodes that correspond to the tails of some
                         (possibly empty) set of edges.
-        :returns: set -- hyperedge_ids of the hyperedges that have tail
-                in the tail.
+        :returns: set -- hyperedge_ids of the directed hyperedges that have
+                tail in the tail.
 
         """
         frozen_tail = frozenset(tail)
@@ -1159,13 +1159,13 @@ class MixedHypergraph(object):
         return set(self._successors[frozen_tail].values())
 
     def get_predecessors(self, head):
-        """Given a head set of nodes, get a list of edges of which the node set
-        is the head of each edge.
+        """Given a head set of nodes, get a list of directed hyperedges
+        of which the node set is the head of each edge.
 
         :param head: set of nodes that correspond to the heads of some
                         (possibly empty) set of edges.
-        :returns: set -- hyperedge_ids of the hyperedges that have head
-                in the head.
+        :returns: set -- hyperedge_ids of the directed hyperedges that have
+                head in the head.
         """
         frozen_head = frozenset(head)
         # If this node set isn't any head in the hypergraph, then it has

--- a/halp/mixed_hypergraph.py
+++ b/halp/mixed_hypergraph.py
@@ -58,7 +58,7 @@ class MixedHypergraph(object):
     """
 
     def __init__(self):
-        """Constructor for the DirectedHypergraph class.
+        """Constructor for the MixedHypergraph class.
         Initializes all internal data structures used for the rapid
         execution of most of the fundamental hypergraph queries.
 
@@ -385,7 +385,6 @@ class MixedHypergraph(object):
         for node in nodes:
             self.remove_node(node)
 
-    # WIP convert
     def trim_node(self, node):
         """Removes a node from the hypergraph. Modifies hyperedges with the 
         trimmed node in their head or tail so that they no longer include 
@@ -516,8 +515,6 @@ class MixedHypergraph(object):
         """
         self._current_hyperedge_id += 1
         return "e" + str(self._current_hyperedge_id)
-
-    # ------------------------------------------ WIP
 
     def add_undirected_hyperedge(self, nodes, attr_dict=None, **attr):
         """Adds an undirected hyperedge to the hypergraph, along with any
@@ -863,7 +860,7 @@ class MixedHypergraph(object):
         Examples:
         ::
 
-            >>> H = DirectedHypergraph()
+            >>> H = MixedHypergraph()
             >>> hyperedge_list = ((["A"], ["B", "C"]),
                                   (("A", "B"), ("C"), {'weight': 2}),
                                   (set(["B"]), set(["A", "C"])))
@@ -875,7 +872,6 @@ class MixedHypergraph(object):
             self.remove_hyperedge(hyperedge_id)
 
     def has_undirected_hyperedge(self, nodes):
-        # Note: Code and comments unchanged from DirectedHypergraph
         """Given a set of nodes, returns whether there is a hyperedge in the
         hypergraph that is precisely composed of those nodes.
 
@@ -1003,11 +999,11 @@ class MixedHypergraph(object):
         Examples:
         ::
 
-            >>> H = DirectedHypergraph()
+            >>> H = MixedHypergraph()
             >>> hyperedge_list = (["A"], ["B", "C"]),
                                   (("A", "B"), ("C"), {weight: 2}),
                                   (set(["B"]), set(["A", "C"])))
-            >>> hyperedge_ids = H.add_hyperedges(hyperedge_list)
+            >>> hyperedge_ids = H.add_directed_hyperedges(hyperedge_list)
             >>> attribute = H.get_hyperedge_attribute(hyperedge_ids[0])
 
         """
@@ -1155,24 +1151,24 @@ class MixedHypergraph(object):
         return set(self._predecessors[frozen_head].values())
 
     def copy(self):
-        """Creates a new DirectedHypergraph object with the same node and
+        """Creates a new MixedHypergraph object with the same node and
         hyperedge structure.
         Copies of the nodes' and hyperedges' attributes are stored
         and used in the new hypergraph.
 
-        :returns: DirectedHypergraph -- a new hypergraph that is a copy of
+        :returns: MixedHypergraph -- a new hypergraph that is a copy of
                 the current hypergraph
 
         """
         return self.__copy__()
 
     def __copy__(self):
-        """Creates a new DirectedHypergraph object with the same node and
+        """Creates a new MixedHypergraph object with the same node and
         hyperedge structure.
         Copies of the nodes' and hyperedges' attributes are stored
         and used in the new hypergraph.
 
-        :returns: DirectedHypergraph -- a new hypergraph that is a copy of
+        :returns: MixedHypergraph -- a new hypergraph that is a copy of
                 the current hypergraph
 
         """
@@ -1275,7 +1271,7 @@ class MixedHypergraph(object):
         of the provided nodes.
 
         :param nodes: the set of nodes to find the induced subhypergraph of.
-        :returns: DirectedHypergraph -- the subhypergraph induced on the
+        :returns: MixedHypergraph -- the subhypergraph induced on the
                 provided nodes.
 
         """
@@ -1510,7 +1506,7 @@ class MixedHypergraph(object):
                     raise ValueError(
                         'Consistency Check 1.7 Failed: hyperedge ' +
                         'id ' + hyperedge_id + ' is not in the ' +
-                        'backward star of head node ' + tail_node)
+                        'backward star of head node ' + head_node)
 
     def _check_node_attributes_consistency(self):
         """Consistency Check 2: consider all nodes listed in

--- a/halp/mixed_hypergraph.py
+++ b/halp/mixed_hypergraph.py
@@ -1270,12 +1270,12 @@ class MixedHypergraph(object):
         # Reverse the tail and head (and __frozen_tail and __frozen_head) for
         # every hyperedge
         for hyperedge_id in self.get_hyperedge_id_set():
-            # WIP check if hyperedges are undirected beforehand
-            attr_dict = new_H._hyperedge_attributes[hyperedge_id]
-            attr_dict["tail"], attr_dict["head"] = \
-                attr_dict["head"], attr_dict["tail"]
-            attr_dict["__frozen_tail"], attr_dict["__frozen_head"] = \
-                attr_dict["__frozen_head"], attr_dict["__frozen_tail"]
+            if self.is_hyperedge_id_directed(hyperedge_id):
+                attr_dict = new_H._hyperedge_attributes[hyperedge_id]
+                attr_dict["tail"], attr_dict["head"] = \
+                    attr_dict["head"], attr_dict["tail"]
+                attr_dict["__frozen_tail"], attr_dict["__frozen_head"] = \
+                    attr_dict["__frozen_head"], attr_dict["__frozen_tail"]
 
         # Reverse the definition of forward star and backward star
         new_H._forward_star, new_H._backward_star = \

--- a/halp/mixed_hypergraph.py
+++ b/halp/mixed_hypergraph.py
@@ -897,9 +897,37 @@ class MixedHypergraph(object):
         """
         return iter(self._hyperedge_attributes)
 
+    def get_undirected_hyperedge_id(self, nodes):
+        """From a set of nodes, returns the ID of the undirected hyperedge
+        that this set comprises.
+
+        :param nodes: iterable container of references to nodes in the
+                    the hyperedge to be added
+        :returns: str -- ID of the hyperedge that has that the specified
+                node set comprises.
+        :raises: ValueError -- No such hyperedge exists.
+
+        Examples:
+        ::
+
+            >>> H = MixedHypergraph()
+            >>> hyperedge_list = (["A", "B", "C"],
+                                  ("A", "D"),
+                                  set(["B", "D"]))
+            >>> hyperedge_ids = H.add_undirected_hyperedges(hyperedge_list)
+            >>> x = H.get_undirected_hyperedge_id(["A", "B", "C"])
+
+        """
+        frozen_nodes = frozenset(nodes)
+
+        if not self.has_undirected_hyperedge(frozen_nodes):
+            raise ValueError("No such hyperedge exists.")
+
+        return self._node_set_to_hyperedge[frozen_nodes]
+
     def get_directed_hyperedge_id(self, tail, head):
-        """From a tail and head set of nodes, returns the ID of the hyperedge
-        that these sets comprise.
+        """From a tail and head set of nodes, returns the ID of the directed
+        hyperedge that these sets comprise.
 
         :param tail: iterable container of references to nodes in the
                     tail of the hyperedge to be added
@@ -912,12 +940,12 @@ class MixedHypergraph(object):
         Examples:
         ::
 
-            >>> H = DirectedHypergraph()
+            >>> H = MixedHypergraph()
             >>> hyperedge_list = (["A"], ["B", "C"]),
                                   (("A", "B"), ("C"), {weight: 2}),
                                   (set(["B"]), set(["A", "C"])))
-            >>> hyperedge_ids = H.add_hyperedges(hyperedge_list)
-            >>> x = H.get_hyperedge_id(["A"], ["B", "C"])
+            >>> hyperedge_ids = H.add_directed_hyperedges(hyperedge_list)
+            >>> x = H.get_directed_hyperedge_id(["A"], ["B", "C"])
 
         """
         frozen_tail = frozenset(tail)

--- a/halp/undirected_hypergraph.py
+++ b/halp/undirected_hypergraph.py
@@ -317,6 +317,55 @@ class UndirectedHypergraph(object):
         for node in nodes:
             self.remove_node(node)
 
+    def trim_node(self, node):
+        """Removes a node from the hypergraph. Modifies hyperedges which contain 
+        the trimmed node that they no longer include 
+        the trimmed node. If a hyperedge has solely the trimmed node,
+        that hyperedge is removed.
+        
+        Note: hyperedges modified this way will have different IDs than before
+        
+        Examples:
+        ::
+        
+            >>> H = UndirectedHypergraph()
+            >>> node_list = ['A', 'B', 'C', 'D']
+            >>> H.add_nodes(node_list)
+            >>> H.add_hyperedge('A','B', 'C','D'])
+            >>> H.trim_node('A')
+        """
+    
+        s = self.get_star(node)
+        remove_set = set()
+    
+        def get_attrs(H, hyperedge):
+            #copies the attribute dictionary of a hyperedge except for the head and tail
+            new_attrs = {}
+            old_attrs = H.get_hyperedge_attributes(hyperedge)
+        
+            for key in old_attrs:
+                if key not in {'head', 'tail'}:
+                    new_attrs[key] = old_attrs[key]
+            return new_attrs
+    
+        for hedge in s:
+            nodes = set(self.get_hyperedge_nodes(hedge))
+            if len(nodes) > 1:
+                new_nodes = nodes - {node}
+                attrs = get_attrs(self, hedge)
+                self.add_hyperedge(new_nodes, attrs)
+            remove_set.add(hedge)
+
+        for hedge in remove_set:
+            self.remove_hyperedge(hedge)
+            
+        self.remove_node(node)
+    
+    def trim_nodes(self, nodes):
+        """Trims multiple nodes from the hypergraph (see trim_node() for details)"""
+        for node in nodes:
+            self.trim_node(node)
+
     def get_node_set(self):
         # Note: Code and comments unchanged from DirectedHypergraph
         """Returns the set of nodes that are currently in the hypergraph.

--- a/halp/undirected_hypergraph.py
+++ b/halp/undirected_hypergraph.py
@@ -335,18 +335,18 @@ class UndirectedHypergraph(object):
             >>> H.trim_node('A')
         """
     
-        s = self.get_star(node)
-        remove_set = set()
-    
         def get_attrs(H, hyperedge):
-            #copies the attribute dictionary of a hyperedge except for the head and tail
+            #copies the attribute dictionary of a hyperedge except for the nodes
             new_attrs = {}
             old_attrs = H.get_hyperedge_attributes(hyperedge)
         
             for key in old_attrs:
-                if key not in {'head', 'tail'}:
+                if key != 'nodes':
                     new_attrs[key] = old_attrs[key]
             return new_attrs
+        
+        remove_set = set()
+        s = self.get_star(node)
     
         for hedge in s:
             nodes = set(self.get_hyperedge_nodes(hedge))

--- a/halp/undirected_hypergraph.py
+++ b/halp/undirected_hypergraph.py
@@ -16,7 +16,7 @@ class UndirectedHypergraph(object):
 
     An undirected hypergraph contains nodes and undirected hyperedges. Each
     undirected hyperedge simply connects a set of nodes. An undirected
-    hypergraph is a special case of an undirected graph, where each edge
+    graph is a special case of an undirected hypergraph, where each edge
     connects exactly 2 nodes. The set of nodes cannot be empty.
 
     A node is simply any hashable type. See "add_node" or "add_nodes" for
@@ -89,7 +89,7 @@ class UndirectedHypergraph(object):
         #
         self._hyperedge_attributes = {}
 
-        # The star of a node is the set of hyperedges such that the
+        # The star of a node is the set of hyperedges the
         # node is a member of.
         #
         # _star: a dictionary mapping a node to the set of hyperedges

--- a/halp/utilities/undirected_matrices.py
+++ b/halp/utilities/undirected_matrices.py
@@ -1,6 +1,6 @@
 """
 .. module:: undirected_matrices
-   :synopsis: Provides various methods for tranforming a hypergraph
+   :synopsis: Provides various methods for transforming a hypergraph
             (or its components) into useful corresponding matrix
             representations.
 """

--- a/tests/data/basic_mixed_hypergraph.txt
+++ b/tests/data/basic_mixed_hypergraph.txt
@@ -1,6 +1,6 @@
 tail	head	direction	weight
 s	x	D	1
-s	y,x	u	2
+x,s	y,x	u	2
 s	z	D	2
 z,y,x	u,t	d	3
 a,u,t		U	1

--- a/tests/data/basic_mixed_hypergraph.txt
+++ b/tests/data/basic_mixed_hypergraph.txt
@@ -1,0 +1,9 @@
+tail	head	direction	weight
+s	x	D	1
+s	y,x	u	2
+s	z	D	2
+z,y,x	u,t	d	3
+a,u,t		U	1
+	x,s	U	1
+b,t	a	D	1
+s	t	D	100

--- a/tests/data/invalid_mixed_hypergraph.txt
+++ b/tests/data/invalid_mixed_hypergraph.txt
@@ -1,0 +1,9 @@
+tail	head	direction	weight
+s	x	D	1
+s	y,x	u	2
+s	z	D	2
+
+a,u,t		U	1
+	x,s		1
+b,t	a	D	1
+s	t	D	100

--- a/tests/data/invalid_mixed_hypergraph_direction.txt
+++ b/tests/data/invalid_mixed_hypergraph_direction.txt
@@ -1,0 +1,9 @@
+tail	head	direction	weight
+s	x	D	1
+s	y,x	F	2
+s	z	D	2
+z,y,x	u,t	D	3
+a,u,t		G	1
+	x,s	U	1
+b,t	a	D	1
+s	t	D	100

--- a/tests/test_directed_hypergraph.py
+++ b/tests/test_directed_hypergraph.py
@@ -38,6 +38,22 @@ def get_hyperedge_id(graph, tail, head):
     else:
         raise ValueError()
 
+def get_hyperedge_head(graph, id):
+    if type(graph) == DirectedHypergraph:
+        return graph.get_hyperedge_head(id)
+    elif type(graph) == MixedHypergraph:
+        return graph.get_directed_hyperedge_head(id)
+    else:
+        raise ValueError()
+
+def get_hyperedge_tail(graph, id):
+    if type(graph) == DirectedHypergraph:
+        return graph.get_hyperedge_tail(id)
+    elif type(graph) == MixedHypergraph:
+        return graph.get_directed_hyperedge_tail(id)
+    else:
+        raise ValueError()
+
 def test_add_node(DirectedHypergraphLike):
     node_a = 'A'
     node_b = 'B'
@@ -583,8 +599,8 @@ def test_get_hyperedge_tail(DirectedHypergraphLike):
     hyperedge_names = \
         add_hyperedges(H, hyperedges, common_attrib, color='white')
 
-    retrieved_tail1 = H.get_hyperedge_tail('e1')
-    retrieved_tail2 = H.get_hyperedge_tail('e2')
+    retrieved_tail1 = get_hyperedge_tail(H, 'e1')
+    retrieved_tail2 = get_hyperedge_tail(H, 'e2')
     assert retrieved_tail1 == tail1
     assert retrieved_tail2 == tail2
 
@@ -614,8 +630,8 @@ def test_get_hyperedge_head(DirectedHypergraphLike):
     hyperedge_names = \
         add_hyperedges(H, hyperedges, common_attrib, color='white')
 
-    retrieved_head1 = H.get_hyperedge_head('e1')
-    retrieved_head2 = H.get_hyperedge_head('e2')
+    retrieved_head1 = get_hyperedge_head(H, 'e1')
+    retrieved_head2 = get_hyperedge_head(H, 'e2')
     assert retrieved_head1 == head1
     assert retrieved_head2 == head2
 
@@ -961,14 +977,14 @@ def test_read_and_write():
     assert H._node_attributes.keys() == new_H._node_attributes.keys()
 
     for new_hyperedge_id in new_H.get_hyperedge_id_set():
-        new_hyperedge_tail = new_H.get_hyperedge_tail(new_hyperedge_id)
-        new_hyperedge_head = new_H.get_hyperedge_head(new_hyperedge_id)
+        new_hyperedge_tail = get_hyperedge_tail(new_H, new_hyperedge_id)
+        new_hyperedge_head = get_hyperedge_head(new_H, new_hyperedge_id)
         new_hyperedge_weight = new_H.get_hyperedge_weight(new_hyperedge_id)
 
         found_matching_hyperedge = False
         for hyperedge_id in H.get_hyperedge_id_set():
-            hyperedge_tail = H.get_hyperedge_tail(hyperedge_id)
-            hyperedge_head = H.get_hyperedge_head(hyperedge_id)
+            hyperedge_tail = get_hyperedge_tail(H, hyperedge_id)
+            hyperedge_head = get_hyperedge_head(H, hyperedge_id)
             hyperedge_weight = H.get_hyperedge_weight(hyperedge_id)
 
             if new_hyperedge_tail == hyperedge_tail and \
@@ -992,7 +1008,7 @@ def test_read_and_write():
         assert False, e
 
 
-def test_check_hyperedge_attributes_consistency(DirectedHypergraphLike):
+def test_check_hyperedge_attributes_consistency():
     # make test hypergraph
     node_a = 'A'
     node_b = 'B'
@@ -1004,7 +1020,7 @@ def test_check_hyperedge_attributes_consistency(DirectedHypergraphLike):
 
     node_d = 'D'
 
-    H = DirectedHypergraphLike()
+    H = DirectedHypergraph()
     H.add_nodes(node_list, common_attrib)
 
     tail1 = set([node_a, node_b])
@@ -1107,7 +1123,7 @@ def test_check_hyperedge_attributes_consistency(DirectedHypergraphLike):
         assert False, e
 
 
-def test_check_node_attributes_consistency(DirectedHypergraphLike):
+def test_check_node_attributes_consistency():
     # make test hypergraph
     node_a = 'A'
     node_b = 'B'
@@ -1119,7 +1135,7 @@ def test_check_node_attributes_consistency(DirectedHypergraphLike):
 
     node_d = 'D'
 
-    H = DirectedHypergraphLike()
+    H = DirectedHypergraph()
     H.add_nodes(node_list, common_attrib)
 
     tail1 = set([node_a, node_b])
@@ -1201,7 +1217,7 @@ def test_check_predecessor_successor_consistency(DirectedHypergraphLike):
 
     node_d = 'D'
 
-    H = DirectedHypergraphLike()
+    H = DirectedHypergraph()
     H.add_nodes(node_list, common_attrib)
 
     tail1 = set([node_a, node_b])
@@ -1264,7 +1280,7 @@ def test_check_predecessor_successor_consistency(DirectedHypergraphLike):
         assert False, e
 
 
-def test_check_hyperedge_id_consistency(DirectedHypergraphLike):
+def test_check_hyperedge_id_consistency():
     # make test hypergraph
     node_a = 'A'
     node_b = 'B'
@@ -1276,7 +1292,7 @@ def test_check_hyperedge_id_consistency(DirectedHypergraphLike):
 
     node_d = 'D'
 
-    H = DirectedHypergraphLike()
+    H = DirectedHypergraph()
     H.add_nodes(node_list, common_attrib)
 
     tail1 = set([node_a, node_b])
@@ -1345,7 +1361,7 @@ def test_check_hyperedge_id_consistency(DirectedHypergraphLike):
         assert False, e
 
 
-def test_check_node_consistency(DirectedHypergraphLike):
+def test_check_node_consistency():
     # make test hypergraph
     node_a = 'A'
     node_b = 'B'
@@ -1357,7 +1373,7 @@ def test_check_node_consistency(DirectedHypergraphLike):
 
     node_d = 'D'
 
-    H = DirectedHypergraphLike()
+    H = DirectedHypergraph()
     H.add_nodes(node_list, common_attrib)
 
     tail1 = set([node_a, node_b])
@@ -1488,7 +1504,8 @@ def test_get_symmetric_image(DirectedHypergraphLike):
 
     sym_H = H.get_symmetric_image()
 
-    sym_H._check_consistency()
+    if type(sym_H) == DirectedHypergraph:
+        sym_H._check_consistency()
 
     assert sym_H._node_attributes == H._node_attributes
 
@@ -1519,8 +1536,12 @@ def test_get_symmetric_image(DirectedHypergraphLike):
 
 
 def test_get_induced_subhypergraph(DirectedHypergraphLike):
-    H = DirectedHypergraphLike()
+    H = DirectedHypergraph()
     H.read("tests/data/basic_directed_hypergraph.txt")
+    if DirectedHypergraphLike == MixedHypergraph:
+        new_H = MixedHypergraph()
+        new_H.extend_directed_hypergraph(H)
+        new_H = H
 
     induce_on_nodes = H.get_node_set() - {'t'}
     induced_H = H.get_induced_subhypergraph(induce_on_nodes)
@@ -1528,8 +1549,8 @@ def test_get_induced_subhypergraph(DirectedHypergraphLike):
     induced_nodes = induced_H.get_node_set()
     assert induced_nodes == H.get_node_set() - {'t'}
 
-    hyperedges = [(induced_H.get_hyperedge_tail(hyperedge_id),
-                   induced_H.get_hyperedge_head(hyperedge_id))
+    hyperedges = [(get_hyperedge_tail(induced_H, hyperedge_id),
+                   get_hyperedge_head(induced_H, hyperedge_id))
                   for hyperedge_id in induced_H.get_hyperedge_id_set()]
     for hyperedge in hyperedges:
         tail, head = hyperedge

--- a/tests/test_directed_hypergraph.py
+++ b/tests/test_directed_hypergraph.py
@@ -1403,7 +1403,7 @@ def test_check_node_consistency(DirectedHypergraphLike):
 
     # Check 5.3.1
     new_H = H.copy()
-    add_hyperedge(new_H, H, "X", "Y")
+    add_hyperedge(new_H, "X", "Y")
     del new_H._node_attributes["X"]
     del new_H._forward_star["X"]
     del new_H._forward_star["Y"]
@@ -1419,7 +1419,7 @@ def test_check_node_consistency(DirectedHypergraphLike):
 
     # Check 5.3.2
     new_H = H.copy()
-    add_hyperedge(new_H, H, "X", "Y")
+    add_hyperedge(new_H, "X", "Y")
     del new_H._node_attributes["Y"]
     del new_H._forward_star["X"]
     del new_H._forward_star["Y"]

--- a/tests/test_directed_hypergraph.py
+++ b/tests/test_directed_hypergraph.py
@@ -24,9 +24,17 @@ def add_hyperedges(graph, hyperedges, attr_dict=None, **attr):
     Adds hyperedges to an instance produced by DirectedHypergraphLike.
     """
     if type(graph) == DirectedHypergraph:
-        return graph. add_hyperedges(hyperedges, attr_dict, **attr)
+        return graph.add_hyperedges(hyperedges, attr_dict, **attr)
     elif type(graph) == MixedHypergraph:
         return graph.add_directed_hyperedges(hyperedges, attr_dict, **attr)
+    else:
+        raise ValueError()
+
+def get_hyperedge_id(graph, tail, head):
+    if type(graph) == DirectedHypergraph:
+        return graph.get_hyperedge_id(tail, head)
+    elif type(graph) == MixedHypergraph:
+        return graph.get_directed_hyperedge_id(tail, head)
     else:
         raise ValueError()
 
@@ -489,12 +497,12 @@ def test_get_hyperedge_id(DirectedHypergraphLike):
     hyperedge_names = \
         add_hyperedges(H, hyperedges, common_attrib, color='white')
 
-    assert H.get_hyperedge_id(tail1, head1) == 'e1'
-    assert H.get_hyperedge_id(tail2, head2) == 'e2'
-    assert H.get_hyperedge_id(tail3, head3) == 'e3'
+    assert get_hyperedge_id(H, tail1, head1) == 'e1'
+    assert get_hyperedge_id(H, tail2, head2) == 'e2'
+    assert get_hyperedge_id(H, tail3, head3) == 'e3'
 
     try:
-        H.get_hyperedge_id(tail1, head2)
+        get_hyperedge_id(H, tail1, head2)
         assert False
     except ValueError:
         pass

--- a/tests/test_directed_hypergraph.py
+++ b/tests/test_directed_hypergraph.py
@@ -1,9 +1,36 @@
 from os import remove
+import pytest
 
 from halp.directed_hypergraph import DirectedHypergraph
+from halp.mixed_hypergraph import MixedHypergraph
 
+@pytest.fixture(params=[DirectedHypergraph, MixedHypergraph])
+def DirectedHypergraphLike(request):
+    return request.param
 
-def test_add_node():
+def add_hyperedge(graph, tail, head, attr_dict=None, **attr):
+    """
+    Adds a hyperedge to an instance produced by DirectedHypergraphLike.
+    """
+    if type(graph) == DirectedHypergraph:
+        return graph.add_hyperedge(tail, head, attr_dict, **attr)
+    elif type(graph) == MixedHypergraph:
+        return graph.add_directed_hyperedge(tail, head, attr_dict, **attr)
+    else:
+        raise ValueError()
+
+def add_hyperedges(graph, hyperedges, attr_dict=None, **attr):
+    """
+    Adds hyperedges to an instance produced by DirectedHypergraphLike.
+    """
+    if type(graph) == DirectedHypergraph:
+        return graph. add_hyperedges(hyperedges, attr_dict, **attr)
+    elif type(graph) == MixedHypergraph:
+        return graph.add_directed_hyperedges(hyperedges, attr_dict, **attr)
+    else:
+        raise ValueError()
+
+def test_add_node(DirectedHypergraphLike):
     node_a = 'A'
     node_b = 'B'
     node_c = 'C'
@@ -12,7 +39,7 @@ def test_add_node():
     attrib_d = {'label': 'black', 'sink': True}
 
     # Test adding unadded nodes with various attribute settings
-    H = DirectedHypergraph()
+    H = DirectedHypergraphLike()
     H.add_node(node_a)
     H.add_node(node_b, source=True)
     H.add_node(node_c, attrib_c)
@@ -45,7 +72,7 @@ def test_add_node():
         assert False, e
 
 
-def test_add_nodes():
+def test_add_nodes(DirectedHypergraphLike):
     node_a = 'A'
     node_b = 'B'
     node_c = 'C'
@@ -58,7 +85,7 @@ def test_add_nodes():
                  (node_c, attrib_c), (node_d, attrib_d)]
 
     # Test adding unadded nodes with various attribute settings
-    H = DirectedHypergraph()
+    H = DirectedHypergraphLike()
     H.add_nodes(node_list, common_attrib)
 
     assert node_a in H._node_attributes
@@ -81,7 +108,7 @@ def test_add_nodes():
         assert node in node_set
 
 
-def test_add_hyperedge():
+def test_add_hyperedge(DirectedHypergraphLike):
     node_a = 'A'
     node_b = 'B'
     node_c = 'C'
@@ -94,9 +121,9 @@ def test_add_hyperedge():
 
     attrib = {'weight': 6, 'color': 'black'}
 
-    H = DirectedHypergraph()
+    H = DirectedHypergraphLike()
     H.add_node(node_a, label=1337)
-    hyperedge_name = H.add_hyperedge(tail, head, attrib, weight=5)
+    hyperedge_name = add_hyperedge(H, tail, head, attrib, weight=5)
 
     assert hyperedge_name == 'e1'
 
@@ -122,12 +149,12 @@ def test_add_hyperedge():
 
     # Test that adding same hyperedge will only update attributes
     new_attrib = {'weight': 10}
-    H.add_hyperedge(tail, head, new_attrib)
+    add_hyperedge(H, tail, head, new_attrib)
     assert H._hyperedge_attributes[hyperedge_name]['weight'] == 10
     assert H._hyperedge_attributes[hyperedge_name]['color'] == 'black'
 
     try:
-        H.add_hyperedge(set(), set())
+        add_hyperedge(H, set(), set())
         assert False
     except ValueError:
         pass
@@ -135,7 +162,7 @@ def test_add_hyperedge():
         assert False, e
 
 
-def test_get_hyperedge_attributes():
+def test_get_hyperedge_attributes(DirectedHypergraphLike):
     node_a = 'A'
     node_b = 'B'
     node_c = 'C'
@@ -148,9 +175,9 @@ def test_get_hyperedge_attributes():
 
     attrib = {'weight': 6, 'color': 'black'}
 
-    H = DirectedHypergraph()
+    H = DirectedHypergraphLike()
     H.add_node(node_a, label=1337)
-    hyperedge_name = H.add_hyperedge(tail, head, attrib, weight=5)
+    hyperedge_name = add_hyperedge(H, tail, head, attrib, weight=5)
 
     assert H.get_hyperedge_attributes(hyperedge_name) == \
         {'tail': tail, 'head': head, 'weight': 5, 'color': 'black'}
@@ -165,7 +192,7 @@ def test_get_hyperedge_attributes():
         assert False, e
 
 
-def test_add_hyperedges():
+def test_add_hyperedges(DirectedHypergraphLike):
     node_a = 'A'
     node_b = 'B'
     node_c = 'C'
@@ -186,9 +213,9 @@ def test_add_hyperedges():
 
     hyperedges = [(tail1, head1, attrib), (tail2, head2)]
 
-    H = DirectedHypergraph()
+    H = DirectedHypergraphLike()
     hyperedge_names = \
-        H.add_hyperedges(hyperedges, common_attrib, color='white')
+        add_hyperedges(H, hyperedges, common_attrib, color='white')
 
     assert 'e1' in hyperedge_names
     assert 'e2' in hyperedge_names
@@ -210,7 +237,7 @@ def test_add_hyperedges():
         assert hyperedge_id in hyperedge_names
 
 
-def test_remove_node():
+def test_remove_node(DirectedHypergraphLike):
     node_a = 'A'
     node_b = 'B'
     node_c = 'C'
@@ -237,9 +264,9 @@ def test_remove_node():
 
     hyperedges = [(tail1, head1, attrib), (tail2, head2), (tail3, head3)]
 
-    H = DirectedHypergraph()
+    H = DirectedHypergraphLike()
     hyperedge_names = \
-        H.add_hyperedges(hyperedges, common_attrib, color='white')
+        add_hyperedges(H, hyperedges, common_attrib, color='white')
     H.remove_node(node_a)
 
     # Test that everything that needed to be removed was removed
@@ -276,7 +303,7 @@ def test_remove_node():
         assert False, e
 
 
-def test_remove_nodes():
+def test_remove_nodes(DirectedHypergraphLike):
     node_a = 'A'
     node_b = 'B'
     node_c = 'C'
@@ -311,9 +338,9 @@ def test_remove_nodes():
                   (tail3, head3),
                   (tail4, head4)]
 
-    H = DirectedHypergraph()
+    H = DirectedHypergraphLike()
     hyperedge_names = \
-        H.add_hyperedges(hyperedges, common_attrib, color='white')
+        add_hyperedges(H, hyperedges, common_attrib, color='white')
     H.remove_nodes([node_a, node_d])
 
     # Test that everything that needed to be removed was removed
@@ -335,7 +362,7 @@ def test_remove_nodes():
     assert frozen_tail3 not in H._predecessors[frozen_head3]
 
 
-def test_remove_hyperedge():
+def test_remove_hyperedge(DirectedHypergraphLike):
     node_a = 'A'
     node_b = 'B'
     node_c = 'C'
@@ -362,9 +389,9 @@ def test_remove_hyperedge():
 
     hyperedges = [(tail1, head1, attrib), (tail2, head2), (tail3, head3)]
 
-    H = DirectedHypergraph()
+    H = DirectedHypergraphLike()
     hyperedge_names = \
-        H.add_hyperedges(hyperedges, common_attrib, color='white')
+        add_hyperedges(H, hyperedges, common_attrib, color='white')
     H.remove_hyperedge('e1')
 
     assert 'e1' not in H._hyperedge_attributes
@@ -384,7 +411,7 @@ def test_remove_hyperedge():
         assert False, e
 
 
-def test_remove_hyperedges():
+def test_remove_hyperedges(DirectedHypergraphLike):
     node_a = 'A'
     node_b = 'B'
     node_c = 'C'
@@ -411,9 +438,9 @@ def test_remove_hyperedges():
 
     hyperedges = [(tail1, head1, attrib), (tail2, head2), (tail3, head3)]
 
-    H = DirectedHypergraph()
+    H = DirectedHypergraphLike()
     hyperedge_names = \
-        H.add_hyperedges(hyperedges, common_attrib, color='white')
+        add_hyperedges(H, hyperedges, common_attrib, color='white')
     H.remove_hyperedges(['e1', 'e3'])
 
     assert 'e1' not in H._hyperedge_attributes
@@ -431,7 +458,7 @@ def test_remove_hyperedges():
     assert 'e3' not in H._backward_star[node_e]
 
 
-def test_get_hyperedge_id():
+def test_get_hyperedge_id(DirectedHypergraphLike):
     node_a = 'A'
     node_b = 'B'
     node_c = 'C'
@@ -458,9 +485,9 @@ def test_get_hyperedge_id():
 
     hyperedges = [(tail1, head1, attrib), (tail2, head2), (tail3, head3)]
 
-    H = DirectedHypergraph()
+    H = DirectedHypergraphLike()
     hyperedge_names = \
-        H.add_hyperedges(hyperedges, common_attrib, color='white')
+        add_hyperedges(H, hyperedges, common_attrib, color='white')
 
     assert H.get_hyperedge_id(tail1, head1) == 'e1'
     assert H.get_hyperedge_id(tail2, head2) == 'e2'
@@ -475,7 +502,7 @@ def test_get_hyperedge_id():
         assert False, e
 
 
-def test_get_hyperedge_attribute():
+def test_get_hyperedge_attribute(DirectedHypergraphLike):
     node_a = 'A'
     node_b = 'B'
     node_c = 'C'
@@ -496,9 +523,9 @@ def test_get_hyperedge_attribute():
 
     hyperedges = [(tail1, head1, attrib), (tail2, head2)]
 
-    H = DirectedHypergraph()
+    H = DirectedHypergraphLike()
     hyperedge_names = \
-        H.add_hyperedges(hyperedges, common_attrib, color='white')
+        add_hyperedges(H, hyperedges, common_attrib, color='white')
 
     assert H.get_hyperedge_attribute('e1', 'weight') == 6
     assert H.get_hyperedge_attribute('e1', 'color') == 'black'
@@ -523,7 +550,7 @@ def test_get_hyperedge_attribute():
         assert False, e
 
 
-def test_get_hyperedge_tail():
+def test_get_hyperedge_tail(DirectedHypergraphLike):
     node_a = 'A'
     node_b = 'B'
     node_c = 'C'
@@ -544,9 +571,9 @@ def test_get_hyperedge_tail():
 
     hyperedges = [(tail1, head1, attrib), (tail2, head2)]
 
-    H = DirectedHypergraph()
+    H = DirectedHypergraphLike()
     hyperedge_names = \
-        H.add_hyperedges(hyperedges, common_attrib, color='white')
+        add_hyperedges(H, hyperedges, common_attrib, color='white')
 
     retrieved_tail1 = H.get_hyperedge_tail('e1')
     retrieved_tail2 = H.get_hyperedge_tail('e2')
@@ -554,7 +581,7 @@ def test_get_hyperedge_tail():
     assert retrieved_tail2 == tail2
 
 
-def test_get_hyperedge_head():
+def test_get_hyperedge_head(DirectedHypergraphLike):
     node_a = 'A'
     node_b = 'B'
     node_c = 'C'
@@ -575,9 +602,9 @@ def test_get_hyperedge_head():
 
     hyperedges = [(tail1, head1, attrib), (tail2, head2)]
 
-    H = DirectedHypergraph()
+    H = DirectedHypergraphLike()
     hyperedge_names = \
-        H.add_hyperedges(hyperedges, common_attrib, color='white')
+        add_hyperedges(H, hyperedges, common_attrib, color='white')
 
     retrieved_head1 = H.get_hyperedge_head('e1')
     retrieved_head2 = H.get_hyperedge_head('e2')
@@ -585,7 +612,7 @@ def test_get_hyperedge_head():
     assert retrieved_head2 == head2
 
 
-def test_get_hyperedge_weight():
+def test_get_hyperedge_weight(DirectedHypergraphLike):
     node_a = 'A'
     node_b = 'B'
     node_c = 'C'
@@ -606,9 +633,9 @@ def test_get_hyperedge_weight():
 
     hyperedges = [(tail1, head1, attrib), (tail2, head2)]
 
-    H = DirectedHypergraph()
+    H = DirectedHypergraphLike()
     hyperedge_names = \
-        H.add_hyperedges(hyperedges, common_attrib, color='white')
+        add_hyperedges(H, hyperedges, common_attrib, color='white')
 
     weight_e1 = H.get_hyperedge_weight('e1')
     weight_e2 = H.get_hyperedge_weight('e2')
@@ -616,7 +643,7 @@ def test_get_hyperedge_weight():
     assert weight_e2 == 1
 
 
-def test_get_node_attribute():
+def test_get_node_attribute(DirectedHypergraphLike):
     node_a = 'A'
     node_b = 'B'
     node_c = 'C'
@@ -626,7 +653,7 @@ def test_get_node_attribute():
     node_list = [node_a, (node_b, {'source': True}), (node_c, attrib_c)]
 
     # Test adding unadded nodes with various attribute settings
-    H = DirectedHypergraph()
+    H = DirectedHypergraphLike()
     H.add_nodes(node_list, common_attrib)
 
     assert H.get_node_attribute(node_a, 'common') is True
@@ -654,7 +681,7 @@ def test_get_node_attribute():
         assert False, e
 
 
-def test_get_node_attributes():
+def test_get_node_attributes(DirectedHypergraphLike):
     node_a = 'A'
     node_b = 'B'
     node_c = 'C'
@@ -663,7 +690,7 @@ def test_get_node_attributes():
     attrib_d = {'label': 'black', 'sink': True}
 
     # Test adding unadded nodes with various attribute settings
-    H = DirectedHypergraph()
+    H = DirectedHypergraphLike()
     H.add_node(node_a)
     H.add_node(node_b, source=True)
     H.add_node(node_c, attrib_c)
@@ -682,7 +709,7 @@ def test_get_node_attributes():
         assert False, e
 
 
-def test_get_forward_star():
+def test_get_forward_star(DirectedHypergraphLike):
     node_a = 'A'
     node_b = 'B'
     node_c = 'C'
@@ -706,8 +733,8 @@ def test_get_forward_star():
 
     hyperedges = [(tail1, head1), (tail2, head2), (tail3, head3)]
 
-    H = DirectedHypergraph()
-    hyperedge_names = H.add_hyperedges(hyperedges)
+    H = DirectedHypergraphLike()
+    hyperedge_names = add_hyperedges(H, hyperedges)
 
     assert H.get_forward_star(node_a) == set(['e1'])
     assert H.get_forward_star(node_b) == set(['e1', 'e2'])
@@ -725,7 +752,7 @@ def test_get_forward_star():
         assert False, e
 
 
-def test_get_backward_star():
+def test_get_backward_star(DirectedHypergraphLike):
     node_a = 'A'
     node_b = 'B'
     node_c = 'C'
@@ -749,8 +776,8 @@ def test_get_backward_star():
 
     hyperedges = [(tail1, head1), (tail2, head2), (tail3, head3)]
 
-    H = DirectedHypergraph()
-    hyperedge_names = H.add_hyperedges(hyperedges)
+    H = DirectedHypergraphLike()
+    hyperedge_names = add_hyperedges(H, hyperedges)
 
     assert H.get_backward_star(node_a) == set(['e2'])
     assert H.get_backward_star(node_b) == set()
@@ -768,7 +795,7 @@ def test_get_backward_star():
         assert False, e
 
 
-def test_get_successors():
+def test_get_successors(DirectedHypergraphLike):
     node_a = 'A'
     node_b = 'B'
     node_c = 'C'
@@ -792,8 +819,8 @@ def test_get_successors():
 
     hyperedges = [(tail1, head1), (tail2, head2), (tail3, head3), (tail3, "F")]
 
-    H = DirectedHypergraph()
-    hyperedge_names = H.add_hyperedges(hyperedges)
+    H = DirectedHypergraphLike()
+    hyperedge_names = add_hyperedges(H, hyperedges)
 
     assert 'e1' in H.get_successors(tail1)
     assert 'e2' in H.get_successors(tail2)
@@ -803,7 +830,7 @@ def test_get_successors():
     assert H.get_successors([node_a]) == set()
 
 
-def test_get_predecessors():
+def test_get_predecessors(DirectedHypergraphLike):
     node_a = 'A'
     node_b = 'B'
     node_c = 'C'
@@ -827,8 +854,8 @@ def test_get_predecessors():
 
     hyperedges = [(tail1, head1), (tail2, head2), (tail3, head3), (tail3, "F")]
 
-    H = DirectedHypergraph()
-    hyperedge_names = H.add_hyperedges(hyperedges)
+    H = DirectedHypergraphLike()
+    hyperedge_names = add_hyperedges(H, hyperedges)
 
     assert 'e1' in H.get_predecessors(head1)
     assert 'e2' in H.get_predecessors(head2)
@@ -838,7 +865,7 @@ def test_get_predecessors():
     assert H.get_predecessors([node_a]) == set()
 
 
-def test_copy():
+def test_copy(DirectedHypergraphLike):
     node_a = 'A'
     node_b = 'B'
     node_c = 'C'
@@ -849,7 +876,7 @@ def test_copy():
 
     node_d = 'D'
 
-    H = DirectedHypergraph()
+    H = DirectedHypergraphLike()
     H.add_nodes(node_list, common_attrib)
 
     tail1 = set([node_a, node_b])
@@ -868,7 +895,7 @@ def test_copy():
     hyperedges = [(tail1, head1, attrib), (tail2, head2)]
 
     hyperedge_names = \
-        H.add_hyperedges(hyperedges, common_attrib, color='white')
+        add_hyperedges(H, hyperedges, common_attrib, color='white')
 
     new_H = H.copy()
 
@@ -882,7 +909,7 @@ def test_copy():
     assert new_H._predecessors == H._predecessors
 
 
-def test_read_and_write():
+def test_read_and_write(DirectedHypergraphLike):
     # Try writing the following hypergraph to a file
     node_a = 'A'
     node_b = 'B'
@@ -894,7 +921,7 @@ def test_read_and_write():
 
     node_d = 'D'
 
-    H = DirectedHypergraph()
+    H = DirectedHypergraphLike()
     H.add_nodes(node_list, common_attrib)
 
     tail1 = set([node_a, node_b])
@@ -913,12 +940,12 @@ def test_read_and_write():
     hyperedges = [(tail1, head1, attrib), (tail2, head2)]
 
     hyperedge_names = \
-        H.add_hyperedges(hyperedges, common_attrib, color='white')
+        add_hyperedges(H, hyperedges, common_attrib, color='white')
 
     H.write("test_directed_read_and_write.txt")
 
     # Try reading the hypergraph that was just written into a new hypergraph
-    new_H = DirectedHypergraph()
+    new_H = DirectedHypergraphLike()
     new_H.read("test_directed_read_and_write.txt")
 
     assert H._node_attributes.keys() == new_H._node_attributes.keys()
@@ -945,7 +972,7 @@ def test_read_and_write():
     remove("test_directed_read_and_write.txt")
 
     # Try reading an invalid hypergraph file
-    invalid_H = DirectedHypergraph()
+    invalid_H = DirectedHypergraphLike()
     try:
         invalid_H.read("tests/data/invalid_directed_hypergraph.txt")
         assert False
@@ -955,7 +982,7 @@ def test_read_and_write():
         assert False, e
 
 
-def test_check_hyperedge_attributes_consistency():
+def test_check_hyperedge_attributes_consistency(DirectedHypergraphLike):
     # make test hypergraph
     node_a = 'A'
     node_b = 'B'
@@ -967,7 +994,7 @@ def test_check_hyperedge_attributes_consistency():
 
     node_d = 'D'
 
-    H = DirectedHypergraph()
+    H = DirectedHypergraphLike()
     H.add_nodes(node_list, common_attrib)
 
     tail1 = set([node_a, node_b])
@@ -986,7 +1013,7 @@ def test_check_hyperedge_attributes_consistency():
     hyperedges = [(tail1, head1, attrib), (tail2, head2)]
 
     hyperedge_names = \
-        H.add_hyperedges(hyperedges, common_attrib, color='white')
+        add_hyperedges(H, hyperedges, common_attrib, color='white')
 
     # This should not fail
     H._check_consistency()
@@ -1070,7 +1097,7 @@ def test_check_hyperedge_attributes_consistency():
         assert False, e
 
 
-def test_check_node_attributes_consistency():
+def test_check_node_attributes_consistency(DirectedHypergraphLike):
     # make test hypergraph
     node_a = 'A'
     node_b = 'B'
@@ -1082,7 +1109,7 @@ def test_check_node_attributes_consistency():
 
     node_d = 'D'
 
-    H = DirectedHypergraph()
+    H = DirectedHypergraphLike()
     H.add_nodes(node_list, common_attrib)
 
     tail1 = set([node_a, node_b])
@@ -1101,7 +1128,7 @@ def test_check_node_attributes_consistency():
     hyperedges = [(tail1, head1, attrib), (tail2, head2)]
 
     hyperedge_names = \
-        H.add_hyperedges(hyperedges, common_attrib, color='white')
+        add_hyperedges(H, hyperedges, common_attrib, color='white')
 
     # This should not fail
     H._check_consistency()
@@ -1152,7 +1179,7 @@ def test_check_node_attributes_consistency():
         assert False, e
 
 
-def test_check_predecessor_successor_consistency():
+def test_check_predecessor_successor_consistency(DirectedHypergraphLike):
     # make test hypergraph
     node_a = 'A'
     node_b = 'B'
@@ -1164,7 +1191,7 @@ def test_check_predecessor_successor_consistency():
 
     node_d = 'D'
 
-    H = DirectedHypergraph()
+    H = DirectedHypergraphLike()
     H.add_nodes(node_list, common_attrib)
 
     tail1 = set([node_a, node_b])
@@ -1183,7 +1210,7 @@ def test_check_predecessor_successor_consistency():
     hyperedges = [(tail1, head1, attrib), (tail2, head2)]
 
     hyperedge_names = \
-        H.add_hyperedges(hyperedges, common_attrib, color='white')
+        add_hyperedges(H, hyperedges, common_attrib, color='white')
 
     # This should not fail
     H._check_consistency()
@@ -1227,7 +1254,7 @@ def test_check_predecessor_successor_consistency():
         assert False, e
 
 
-def test_check_hyperedge_id_consistency():
+def test_check_hyperedge_id_consistency(DirectedHypergraphLike):
     # make test hypergraph
     node_a = 'A'
     node_b = 'B'
@@ -1239,7 +1266,7 @@ def test_check_hyperedge_id_consistency():
 
     node_d = 'D'
 
-    H = DirectedHypergraph()
+    H = DirectedHypergraphLike()
     H.add_nodes(node_list, common_attrib)
 
     tail1 = set([node_a, node_b])
@@ -1258,7 +1285,7 @@ def test_check_hyperedge_id_consistency():
     hyperedges = [(tail1, head1, attrib), (tail2, head2)]
 
     hyperedge_names = \
-        H.add_hyperedges(hyperedges, common_attrib, color='white')
+        add_hyperedges(H, hyperedges, common_attrib, color='white')
 
     # This should not fail
     H._check_consistency()
@@ -1308,7 +1335,7 @@ def test_check_hyperedge_id_consistency():
         assert False, e
 
 
-def test_check_node_consistency():
+def test_check_node_consistency(DirectedHypergraphLike):
     # make test hypergraph
     node_a = 'A'
     node_b = 'B'
@@ -1320,7 +1347,7 @@ def test_check_node_consistency():
 
     node_d = 'D'
 
-    H = DirectedHypergraph()
+    H = DirectedHypergraphLike()
     H.add_nodes(node_list, common_attrib)
 
     tail1 = set([node_a, node_b])
@@ -1339,7 +1366,7 @@ def test_check_node_consistency():
     hyperedges = [(tail1, head1, attrib), (tail2, head2)]
 
     hyperedge_names = \
-        H.add_hyperedges(hyperedges, common_attrib, color='white')
+        add_hyperedges(H, hyperedges, common_attrib, color='white')
 
     # This should not fail
     H._check_consistency()
@@ -1368,7 +1395,7 @@ def test_check_node_consistency():
 
     # Check 5.3.1
     new_H = H.copy()
-    new_H.add_hyperedge("X", "Y")
+    add_hyperedge(new_H, H, "X", "Y")
     del new_H._node_attributes["X"]
     del new_H._forward_star["X"]
     del new_H._forward_star["Y"]
@@ -1384,7 +1411,7 @@ def test_check_node_consistency():
 
     # Check 5.3.2
     new_H = H.copy()
-    new_H.add_hyperedge("X", "Y")
+    add_hyperedge(new_H, H, "X", "Y")
     del new_H._node_attributes["Y"]
     del new_H._forward_star["X"]
     del new_H._forward_star["Y"]
@@ -1422,7 +1449,7 @@ def test_check_node_consistency():
         assert False, e
 
 
-def test_get_symmetric_image():
+def test_get_symmetric_image(DirectedHypergraphLike):
     node_a = 'A'
     node_b = 'B'
     node_c = 'C'
@@ -1446,8 +1473,8 @@ def test_get_symmetric_image():
 
     hyperedges = [(tail1, head1), (tail2, head2), (tail3, head3)]
 
-    H = DirectedHypergraph()
-    hyperedge_names = H.add_hyperedges(hyperedges)
+    H = DirectedHypergraphLike()
+    hyperedge_names = add_hyperedges(H, hyperedges)
 
     sym_H = H.get_symmetric_image()
 
@@ -1481,8 +1508,8 @@ def test_get_symmetric_image():
     assert sym_H._backward_star[node_e] == set()
 
 
-def test_get_induced_subhypergraph():
-    H = DirectedHypergraph()
+def test_get_induced_subhypergraph(DirectedHypergraphLike):
+    H = DirectedHypergraphLike()
     H.read("tests/data/basic_directed_hypergraph.txt")
 
     induce_on_nodes = H.get_node_set() - {'t'}
@@ -1501,61 +1528,61 @@ def test_get_induced_subhypergraph():
         assert H.has_hyperedge(tail, head)
 
 
-def test_is_B_hypergraph():
-    H = DirectedHypergraph()
+def test_is_B_hypergraph(DirectedHypergraphLike):
+    H = DirectedHypergraphLike()
     H.read("tests/data/basic_directed_hypergraph.txt")
 
     assert not H.is_B_hypergraph()
 
-    H = DirectedHypergraph()
-    H.add_hyperedge(['a', 'b'], ['c'])
+    H = DirectedHypergraphLike()
+    add_hyperedge(H, ['a', 'b'], ['c'])
     assert H.is_B_hypergraph()
 
-    H = DirectedHypergraph()
-    H.add_hyperedge(['x'], ['y', 'z'])
+    H = DirectedHypergraphLike()
+    add_hyperedge(H, ['x'], ['y', 'z'])
     assert not H.is_B_hypergraph()
 
-    H = DirectedHypergraph()
-    H.add_hyperedge(['a', 'b'], ['c'])
-    H.add_hyperedge(['x'], ['y', 'z'])
+    H = DirectedHypergraphLike()
+    add_hyperedge(H, ['a', 'b'], ['c'])
+    add_hyperedge(H, ['x'], ['y', 'z'])
     assert not H.is_B_hypergraph()
 
 
-def test_is_F_hypergraph():
-    H = DirectedHypergraph()
+def test_is_F_hypergraph(DirectedHypergraphLike):
+    H = DirectedHypergraphLike()
     H.read("tests/data/basic_directed_hypergraph.txt")
 
     assert not H.is_F_hypergraph()
 
-    H = DirectedHypergraph()
-    H.add_hyperedge(['a', 'b'], ['c'])
+    H = DirectedHypergraphLike()
+    add_hyperedge(H, ['a', 'b'], ['c'])
     assert not H.is_F_hypergraph()
 
-    H = DirectedHypergraph()
-    H.add_hyperedge(['x'], ['y', 'z'])
+    H = DirectedHypergraphLike()
+    add_hyperedge(H, ['x'], ['y', 'z'])
     assert H.is_F_hypergraph()
 
-    H = DirectedHypergraph()
-    H.add_hyperedge(['a', 'b'], ['c'])
-    H.add_hyperedge(['x'], ['y', 'z'])
+    H = DirectedHypergraphLike()
+    add_hyperedge(H, ['a', 'b'], ['c'])
+    add_hyperedge(H, ['x'], ['y', 'z'])
     assert not H.is_F_hypergraph()
 
 
-def test_is_BF_hypergraph():
-    H = DirectedHypergraph()
+def test_is_BF_hypergraph(DirectedHypergraphLike):
+    H = DirectedHypergraphLike()
     H.read("tests/data/basic_directed_hypergraph.txt")
 
     assert not H.is_BF_hypergraph()
 
-    H = DirectedHypergraph()
-    H.add_hyperedge(['a', 'b'], ['c'])
+    H = DirectedHypergraphLike()
+    add_hyperedge(H, ['a', 'b'], ['c'])
     assert H.is_BF_hypergraph()
 
-    H = DirectedHypergraph()
-    H.add_hyperedge(['x'], ['y', 'z'])
+    H = DirectedHypergraphLike()
+    add_hyperedge(H, ['x'], ['y', 'z'])
     assert H.is_BF_hypergraph()
 
-    H = DirectedHypergraph()
-    H.add_hyperedge(['a', 'b'], ['c'])
-    H.add_hyperedge(['x'], ['y', 'z'])
+    H = DirectedHypergraphLike()
+    add_hyperedge(H, ['a', 'b'], ['c'])
+    add_hyperedge(H, ['x'], ['y', 'z'])
     assert H.is_BF_hypergraph()

--- a/tests/test_directed_hypergraph.py
+++ b/tests/test_directed_hypergraph.py
@@ -917,7 +917,9 @@ def test_copy(DirectedHypergraphLike):
     assert new_H._predecessors == H._predecessors
 
 
-def test_read_and_write(DirectedHypergraphLike):
+# This specifically tests DirectedHypergraph#read and DirectedHypergraph#write.
+# Please see test_mixed_hypergraph for the mixed hypergraph r/w test.
+def test_read_and_write():
     # Try writing the following hypergraph to a file
     node_a = 'A'
     node_b = 'B'
@@ -929,7 +931,7 @@ def test_read_and_write(DirectedHypergraphLike):
 
     node_d = 'D'
 
-    H = DirectedHypergraphLike()
+    H = DirectedHypergraph()
     H.add_nodes(node_list, common_attrib)
 
     tail1 = set([node_a, node_b])
@@ -953,7 +955,7 @@ def test_read_and_write(DirectedHypergraphLike):
     H.write("test_directed_read_and_write.txt")
 
     # Try reading the hypergraph that was just written into a new hypergraph
-    new_H = DirectedHypergraphLike()
+    new_H = DirectedHypergraph()
     new_H.read("test_directed_read_and_write.txt")
 
     assert H._node_attributes.keys() == new_H._node_attributes.keys()
@@ -980,7 +982,7 @@ def test_read_and_write(DirectedHypergraphLike):
     remove("test_directed_read_and_write.txt")
 
     # Try reading an invalid hypergraph file
-    invalid_H = DirectedHypergraphLike()
+    invalid_H = DirectedHypergraph()
     try:
         invalid_H.read("tests/data/invalid_directed_hypergraph.txt")
         assert False
@@ -1535,62 +1537,62 @@ def test_get_induced_subhypergraph(DirectedHypergraphLike):
         assert set(head) - induce_on_nodes == set()
         assert H.has_hyperedge(tail, head)
 
-
-def test_is_B_hypergraph(DirectedHypergraphLike):
-    H = DirectedHypergraphLike()
+# A B-hypergraph is a property only shared to DirectedHypergraphs.
+def test_is_B_hypergraph():
+    H = DirectedHypergraph()
     H.read("tests/data/basic_directed_hypergraph.txt")
 
     assert not H.is_B_hypergraph()
 
-    H = DirectedHypergraphLike()
+    H = DirectedHypergraph()
     add_hyperedge(H, ['a', 'b'], ['c'])
     assert H.is_B_hypergraph()
 
-    H = DirectedHypergraphLike()
+    H = DirectedHypergraph()
     add_hyperedge(H, ['x'], ['y', 'z'])
     assert not H.is_B_hypergraph()
 
-    H = DirectedHypergraphLike()
+    H = DirectedHypergraph()
     add_hyperedge(H, ['a', 'b'], ['c'])
     add_hyperedge(H, ['x'], ['y', 'z'])
     assert not H.is_B_hypergraph()
 
-
-def test_is_F_hypergraph(DirectedHypergraphLike):
-    H = DirectedHypergraphLike()
+# A B-hypergraph is a property only shared to DirectedHypergraphs.
+def test_is_F_hypergraph():
+    H = DirectedHypergraph()
     H.read("tests/data/basic_directed_hypergraph.txt")
 
     assert not H.is_F_hypergraph()
 
-    H = DirectedHypergraphLike()
+    H = DirectedHypergraph()
     add_hyperedge(H, ['a', 'b'], ['c'])
     assert not H.is_F_hypergraph()
 
-    H = DirectedHypergraphLike()
+    H = DirectedHypergraph()
     add_hyperedge(H, ['x'], ['y', 'z'])
     assert H.is_F_hypergraph()
 
-    H = DirectedHypergraphLike()
+    H = DirectedHypergraph()
     add_hyperedge(H, ['a', 'b'], ['c'])
     add_hyperedge(H, ['x'], ['y', 'z'])
     assert not H.is_F_hypergraph()
 
-
-def test_is_BF_hypergraph(DirectedHypergraphLike):
-    H = DirectedHypergraphLike()
+# A B-hypergraph is a property only shared to DirectedHypergraphs.
+def test_is_BF_hypergraph():
+    H = DirectedHypergraph()
     H.read("tests/data/basic_directed_hypergraph.txt")
 
     assert not H.is_BF_hypergraph()
 
-    H = DirectedHypergraphLike()
+    H = DirectedHypergraph()
     add_hyperedge(H, ['a', 'b'], ['c'])
     assert H.is_BF_hypergraph()
 
-    H = DirectedHypergraphLike()
+    H = DirectedHypergraph()
     add_hyperedge(H, ['x'], ['y', 'z'])
     assert H.is_BF_hypergraph()
 
-    H = DirectedHypergraphLike()
+    H = DirectedHypergraph()
     add_hyperedge(H, ['a', 'b'], ['c'])
     add_hyperedge(H, ['x'], ['y', 'z'])
     assert H.is_BF_hypergraph()

--- a/tests/test_mixed_hypergraph.py
+++ b/tests/test_mixed_hypergraph.py
@@ -130,6 +130,19 @@ def test_read_copy():
     correct(H)
     correct(H.copy())
 
+def test_symmetric_image():
+    H = MixedHypergraph()
+    H.add_undirected_hyperedge(['A', 'B', 'C'])
+    H.add_directed_hyperedge(['A'], ['B', 'C'])
+
+    assert len(H.get_hyperedge_id_set()) == 2
+
+    new_H = H.get_symmetric_image()
+    assert len(new_H.get_hyperedge_id_set()) == 2
+
+    new_H.get_undirected_hyperedge_id(['A', 'B', 'C'])
+    new_H.get_directed_hyperedge_id(['B', 'C'], ['A'])
+
 def test_write():
     H = MixedHypergraph()
     H.add_nodes(['A', 'B', 'C'])

--- a/tests/test_mixed_hypergraph.py
+++ b/tests/test_mixed_hypergraph.py
@@ -1,3 +1,112 @@
 from os import remove
 
+from halp.undirected_hypergraph import UndirectedHypergraph
+from halp.directed_hypergraph import DirectedHypergraph
 from halp.mixed_hypergraph import MixedHypergraph
+
+# Since most of the tests for basic, single-direction usage of hypergraphs
+# reutilize the tests in test_undirected_hypergraph and test_directed_hypergraph,
+# the tests here specifically focus on features pertaining to mixed hypergraphs.
+ 
+def test_direction_preservation():
+    graph = MixedHypergraph()
+    graph.add_nodes(['A', 'B', 'C', 'D', 'E', 'F'])
+    graph.add_undirected_hyperedge(['A', 'B', 'C'])
+    graph.add_directed_hyperedge(['C', 'F'], ['D', 'E'])
+
+    directed_edge = graph.get_directed_hyperedge_id(['C', 'F'], ['D', 'E'])
+    assert graph.is_hyperedge_id_directed(directed_edge)
+
+    undirected_edge = graph.get_undirected_hyperedge_id(['A', 'B', 'C'])
+    assert graph.is_hyperedge_id_undirected(undirected_edge)
+
+def test_underlying_graph():
+    graph = MixedHypergraph()
+    graph.add_nodes(['A', 'B', 'C', 'D'])
+    graph.add_undirected_hyperedge(['A', 'B', 'C', 'D'])
+    graph.add_directed_hyperedge(['A', 'B'], ['C'])
+    graph.add_directed_hyperedge(['B'], ['C', 'D'])
+
+    undirected = graph.underlying_undirected_hypergraph()
+    assert undirected.has_hyperedge(['A', 'B', 'C', 'D'])
+    assert len(undirected.get_hyperedge_id_set()) == 1
+
+    directed = graph.underlying_directed_hypergraph()
+    assert directed.has_hyperedge(['A', 'B'], ['C'])
+    assert directed.has_hyperedge(['B'], ['C', 'D'])
+    assert len(directed.get_hyperedge_id_set()) == 2
+
+def test_extend():
+    H = MixedHypergraph()
+
+    H_u = UndirectedHypergraph()
+    H_u.add_nodes(['A', 'B', 'C'])
+    H_u.add_hyperedge(['A', 'B'])
+    H_u.add_hyperedge(['B', 'C'])
+    H.extend_undirected_hypergraph(H_u)
+    assert len(H.get_hyperedge_id_set()) == 2
+    assert len(H.get_node_set()) == 3
+
+    H_d = DirectedHypergraph()
+    H_d.add_nodes(['D', 'E', 'F'])
+    H_d.add_hyperedge(['D'], ['E', 'F'])
+    H_d.add_hyperedge(['D', 'E'], ['F'])
+    H_d.add_hyperedge(['A'], ['D'])
+    H.extend_directed_hypergraph(H_d)
+    assert len(H.get_hyperedge_id_set()) == 5
+    assert len(H.get_node_set()) == 6
+
+    H.get_directed_hyperedge_id(['A'], ['D'])
+
+def test_read_invalid_basic():
+    invalid_H = MixedHypergraph()
+    try:
+        invalid_H.read("tests/data/invalid_mixed_hypergraph.txt")
+        assert False
+    except IOError:
+        pass
+    except BaseException as e:
+        assert False, e
+    
+def test_read_invalid_direction():
+    invalid_H = MixedHypergraph()
+    try:
+        invalid_H.read("tests/data/invalid_mixed_hypergraph_direction.txt")
+        assert False
+    except IOError:
+        pass
+    except BaseException as e:
+        assert False, e
+
+def test_read():
+    H = MixedHypergraph()
+    H.read("tests/data/basic_mixed_hypergraph.txt")
+
+    # correctness checks
+    H.get_undirected_hyperedge_id(['s', 'y', 'x'])
+    H.get_undirected_hyperedge_id(['x', 's'])
+    H.get_undirected_hyperedge_id(['a', 'u', 't'])
+
+    H.get_directed_hyperedge_id(['s'], ['x'])
+
+def test_write():
+    H = MixedHypergraph()
+    H.add_nodes(['A', 'B', 'C'])
+
+    H.add_directed_hyperedge(['A'], ['B', 'C'])
+    H.add_directed_hyperedge(['A', 'B'], ['C'])
+    H.add_undirected_hyperedge(['A', 'B'])
+    H.add_undirected_hyperedge(['B', 'C'])
+
+    H.write('test_mixed_read_and_write.txt')
+
+    # read the just written file
+    new_H = MixedHypergraph()
+    new_H.read('test_mixed_read_and_write.txt')
+
+    new_H.get_directed_hyperedge_id(['A'], ['B', 'C'])
+    new_H.get_directed_hyperedge_id(['A', 'B'], ['C'])
+    new_H.get_undirected_hyperedge_id(['A', 'B'])
+    new_H.get_undirected_hyperedge_id(['B', 'C'])
+
+    remove('test_mixed_read_and_write.txt')

--- a/tests/test_mixed_hypergraph.py
+++ b/tests/test_mixed_hypergraph.py
@@ -1,0 +1,3 @@
+from os import remove
+
+from halp.mixed_hypergraph import MixedHypergraph

--- a/tests/test_mixed_hypergraph.py
+++ b/tests/test_mixed_hypergraph.py
@@ -78,16 +78,57 @@ def test_read_invalid_direction():
     except BaseException as e:
         assert False, e
 
-def test_read():
+def test_overlapping():
+    H = MixedHypergraph()
+    H.add_undirected_hyperedge(['A', 'B', 'C'])
+    H.add_undirected_hyperedge(['A', 'C', 'B'])
+    H.add_directed_hyperedges([(['A', 'B'], ['C']),
+                               (['A'], ['B', 'C']),
+                               (['A'], ['C', 'B'])])
+    
+    assert len(H.get_hyperedge_id_set()) == 3
+
+def test_get_hyperedge_nodes():
+    H = MixedHypergraph()
+    id = H.add_directed_hyperedge(['A', 'C'], ['B'])
+    assert H.get_hyperedge_nodes(id) == set(['A', 'B', 'C'])
+
+def test_trim_node():
+    H = MixedHypergraph()
+    H.add_undirected_hyperedge(['A', 'B', 'C'])
+    H.add_directed_hyperedge(['A'], ['B', 'C'])
+    H.trim_nodes(['C'])
+
+    assert len(H.get_node_set()) == 2
+    assert len(H.get_hyperedge_id_set()) == 2
+
+    H.get_undirected_hyperedge_id(['A', 'B'])
+    H.get_directed_hyperedge_id(['A'], ['B'])
+
+    H.trim_node('B')
+
+    assert len(H.get_node_set()) == 1
+    assert len(H.get_hyperedge_id_set()) == 1
+
+    H.get_undirected_hyperedge_id(['A'])
+
+def test_read_copy():
     H = MixedHypergraph()
     H.read("tests/data/basic_mixed_hypergraph.txt")
 
-    # correctness checks
-    H.get_undirected_hyperedge_id(['s', 'y', 'x'])
-    H.get_undirected_hyperedge_id(['x', 's'])
-    H.get_undirected_hyperedge_id(['a', 'u', 't'])
+    def correct(G):
+        # correctness checks
+        assert len(H.get_hyperedge_id_set()) == 8
+        assert len(H.get_node_set()) == 8
 
-    H.get_directed_hyperedge_id(['s'], ['x'])
+        G.get_undirected_hyperedge_id(['s', 'y', 'x'])
+        G.get_undirected_hyperedge_id(['x', 's'])
+        G.get_undirected_hyperedge_id(['a', 'u', 't'])
+
+        G.get_directed_hyperedge_id(['s'], ['x'])
+    
+    correct(H)
+    correct(H.copy())
 
 def test_write():
     H = MixedHypergraph()

--- a/tests/test_undirected_hypergraph.py
+++ b/tests/test_undirected_hypergraph.py
@@ -41,6 +41,17 @@ def get_hyperedge_id(graph, nodes):
     else:
         raise ValueError()
 
+def get_hyperedge_nodes(graph, nodes):
+    """
+    Adds hyperedges to an instance produced by UndirectedHypergraphLike.
+    """
+    if type(graph) == UndirectedHypergraph:
+        return graph.get_hyperedge_id(nodes)
+    elif type(graph) == MixedHypergraph:
+        return graph.get_undirected_hyperedge_id(nodes)
+    else:
+        raise ValueError()
+
 def test_add_node(UndirectedHypergraphLike):
     node_a = 'A'
     node_b = 'B'

--- a/tests/test_undirected_hypergraph.py
+++ b/tests/test_undirected_hypergraph.py
@@ -15,7 +15,7 @@ def add_hyperedge(graph, nodes, attr_dict=None, **attr):
     if type(graph) == UndirectedHypergraph:
         return graph.add_hyperedge(nodes, attr_dict, **attr)
     elif type(graph) == MixedHypergraph:
-        return graph.add_directed_hyperedge(nodes, attr_dict, **attr)
+        return graph.add_undirected_hyperedge(nodes, attr_dict, **attr)
     else:
         raise ValueError()
 
@@ -27,6 +27,17 @@ def add_hyperedges(graph, hyperedges, attr_dict=None, **attr):
         return graph.add_hyperedges(hyperedges, attr_dict, **attr)
     elif type(graph) == MixedHypergraph:
         return graph.add_undirected_hyperedges(hyperedges, attr_dict, **attr)
+    else:
+        raise ValueError()
+
+def get_hyperedge_id(graph, nodes):
+    """
+    Adds hyperedges to an instance produced by UndirectedHypergraphLike.
+    """
+    if type(graph) == UndirectedHypergraph:
+        return graph.get_hyperedge_id(nodes)
+    elif type(graph) == MixedHypergraph:
+        return graph.get_undirected_hyperedge_id(nodes)
     else:
         raise ValueError()
 
@@ -380,12 +391,12 @@ def test_get_hyperedge_id(UndirectedHypergraphLike):
     hyperedge_names = \
         add_hyperedges(H, hyperedges, common_attrib, color='white')
 
-    assert H.get_hyperedge_id(nodes1) == 'e1'
-    assert H.get_hyperedge_id(nodes2) == 'e2'
-    assert H.get_hyperedge_id(nodes3) == 'e3'
+    assert get_hyperedge_id(H, nodes1) == 'e1'
+    assert get_hyperedge_id(H, nodes2) == 'e2'
+    assert get_hyperedge_id(H, nodes3) == 'e3'
 
     try:
-        H.get_hyperedge_id(set([node_a, node_b, node_c, node_d]))
+        get_hyperedge_id(H, set([node_a, node_b, node_c, node_d]))
         assert False
     except ValueError:
         pass

--- a/tests/test_undirected_hypergraph.py
+++ b/tests/test_undirected_hypergraph.py
@@ -377,6 +377,21 @@ def test_remove_nodes(UndirectedHypergraphLike):
     assert "e3" not in H._hyperedge_attributes
     assert frozen_nodes3 not in H._node_set_to_hyperedge
 
+def test_trim_nodes(UndirectedHypergraphLike):
+    H = UndirectedHypergraphLike()
+    add_hyperedge(H, ['A', 'B', 'C'])
+    add_hyperedge(H, ['C', 'D'])
+
+    H.trim_node('C')
+
+    assert len(H.get_hyperedge_id_set()) == 2
+    get_hyperedge_id(H, ['A', 'B'])
+    get_hyperedge_id(H, ['D'])
+
+    H.trim_node('D')
+
+    assert len(H.get_hyperedge_id_set()) == 1
+    get_hyperedge_id(H, ['A', 'B'])
 
 def test_get_hyperedge_id(UndirectedHypergraphLike):
     node_a = 'A'

--- a/tests/test_undirected_hypergraph.py
+++ b/tests/test_undirected_hypergraph.py
@@ -689,8 +689,10 @@ def test_copy(UndirectedHypergraphLike):
     assert new_H._node_set_to_hyperedge == H._node_set_to_hyperedge
 
 
-def test_read_and_write(UndirectedHypergraphLike):
-    # Try writing the following hypergraph to a file
+# This specifically tests UndirectedHypergraph#read and UndirectedHypergraph#write.
+# Please see test_mixed_hypergraph for the mixed hypergraph r/w test.
+def test_read_and_write():
+    # Try writing the following hypergraph to a file.
     node_a = 'A'
     node_b = 'B'
     node_c = 'C'
@@ -710,14 +712,14 @@ def test_read_and_write(UndirectedHypergraphLike):
 
     hyperedges = hyperedges = [nodes1, nodes2, nodes3]
 
-    H = UndirectedHypergraphLike()
+    H = UndirectedHypergraph()
     hyperedge_names = \
         add_hyperedges(H, hyperedges, common_attrib, color='white')
 
     H.write("test_undirected_read_and_write.txt")
 
     # Try reading the hypergraph that was just written into a new hypergraph
-    new_H = UndirectedHypergraphLike()
+    new_H = UndirectedHypergraph()
     new_H.read("test_undirected_read_and_write.txt")
 
     assert H._node_attributes.keys() == new_H._node_attributes.keys()
@@ -741,7 +743,7 @@ def test_read_and_write(UndirectedHypergraphLike):
     remove("test_undirected_read_and_write.txt")
 
     # Try reading an invalid hypergraph file
-    invalid_H = UndirectedHypergraphLike()
+    invalid_H = UndirectedHypergraph()
     try:
         invalid_H.read("tests/data/invalid_undirected_hypergraph.txt")
         assert False


### PR DESCRIPTION
This adds mixed hypergraphs, or hypergraphs that can have both directed and undirected hyperedges. For the internal representation, we keep all three star dicts (forward/backward star from directed hypergraphs, star from undirected hypergraphs) and use that to keep track (along with the membership of `__frozen_nodes`/`__frozen_head`/`__frozen_tail`) of what hyperedges are what.

Generally, since `mixed_hypergraph.py` shares a lot of code, we try to use the exact same naming scheme from the other two hypergraph implementations as much as possible.

This PR also fixes some documentation and function inconsistencies along the way. (Most notably, the introduction of `trim_node` to `UndirectedHypergraph` with associated tests).

For testing, while the main mixed hypergraph testing file is small, almost all of the tests in the undirected/directed hypergraph testing files have been modified to also be tested on mixed graphs.

_Note_: This does not implement any algorithms; only the data structure itself.